### PR TITLE
added tab change event

### DIFF
--- a/src/components/SweetModal.vue
+++ b/src/components/SweetModal.vue
@@ -343,6 +343,8 @@
 			_changeTab(tab) {
 				this.tabs.map(t => t.active = t == tab)
 				this.currentTab = tab
+
+                		this.$emit('tab-change', tab)
 			},
 
 			_getClassesForTab(tab) {


### PR DESCRIPTION
I found this event useful for being able to detect when the tab changes to refresh certain UI elements that can't be rendered properly when hidden in another tab.