### PR TITLE
fixes viewport height issue in Chrome mobile

### DIFF
--- a/src/components/SweetModal.vue
+++ b/src/components/SweetModal.vue
@@ -438,7 +438,7 @@
 		left: 0;
 
 		width: 100vw;
-		height: 100vh;
+		height: 100%;
 
 		z-index: 9001;
 
@@ -857,7 +857,7 @@
 
 				& {
 					width: 100%;
-					height: 100vh;
+					height: 100%;
 
 					left: 0;
 					top: 0;


### PR DESCRIPTION
In Chrome Mobile the buttons in the bottom of the modal disappear when the address bar is visible. This is because in Chrome Mobile the address bar is calculated into the viewport height. 
see also https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile

This PR fixes the issue by using percentage instead of viewport height to make the modal fullscreen.

Example screenshot without fix:

![example without fix](https://user-images.githubusercontent.com/17717159/88670881-eb2e7500-d0e5-11ea-96a4-e568298480d0.jpg)

Example screenshot with fix:

![example with fix](https://user-images.githubusercontent.com/17717159/88670899-f1bcec80-d0e5-11ea-88e2-0fd4311e0956.jpg)
